### PR TITLE
fix changing VM's alias

### DIFF
--- a/src/cljs/cerberus/howl.cljs
+++ b/src/cljs/cerberus/howl.cljs
@@ -54,6 +54,10 @@
      :data  {:action "deleted" :uuid snap-id}}]
    (delete-state! [:vms :elements channel :snapshots (keyword snap-id)])
 
+   ;; currently only update "alias"
+   [{:event "update", :data {:config {:alias alias}}}]
+   (set-state! [:vms :elements channel :alias] alias)
+
    [_]
    (dbg/warning "[howl] unknown message:" channel message)))
 

--- a/src/cljs/cerberus/hypervisors/api.cljs
+++ b/src/cljs/cerberus/hypervisors/api.cljs
@@ -10,7 +10,7 @@
 (def root :hypervisors)
 
 (def list-fields
-  "uuid,version,alias,resources,sysinfo,last_seen")
+  "uuid,version,alias,resources,sysinfo,last_seen,host")
 
 (defn list [data]
   (api/list data root list-fields))

--- a/src/cljs/cerberus/packages/create.cljs
+++ b/src/cljs/cerberus/packages/create.cljs
@@ -40,7 +40,7 @@
 
 (defn rule-type [weight]
   (cond
-    (or (#{"must" "cant"} weight) (number? weight)) :normal
+    (or (#{"must" "cant"} weight) (re-matches #"^\d+$" weight)) :normal
     (= weight "scale") :scale
     (= weight "random") :random
     :else false)

--- a/src/cljs/cerberus/packages/create.cljs
+++ b/src/cljs/cerberus/packages/create.cljs
@@ -61,7 +61,7 @@
     :random (if (valid attribute low high)
               {:weight "random" :low (str->int low) :high (str->int high)})
     :normal (if (valid attribute condition value)
-              {:weight weight :attribute attribute :condition condition
+              {:weight (convert-value "" weight) :attribute attribute :condition condition
                :value (convert-value condition value)})
     nil))
 

--- a/src/cljs/cerberus/permissions.cljs
+++ b/src/cljs/cerberus/permissions.cljs
@@ -64,7 +64,7 @@
 
 (def org-perms
   (assoc perm-perms
-         "join"   {:title "Join a role"}))
+         "join"   {:title "Join a org"}))
 
 (def user-perms
   (assoc perm-perms

--- a/src/cljs/cerberus/roles.cljs
+++ b/src/cljs/cerberus/roles.cljs
@@ -35,6 +35,6 @@
     (render-state [_ _]
       (condp = (:view data)
         :list (del/with-delete
-                data root :name (partial roles/delete data)
+                data root :name roles/delete
                 (om/build jlist/view data {:opts {:config config}}))
         :show (om/build view/render data {})))))


### PR DESCRIPTION
cerberus does not handle the "update" event;

this fix only handles alias.